### PR TITLE
added CRUD methods to the API / Promise refactoring

### DIFF
--- a/lib/api/entityAndGroups.js
+++ b/lib/api/entityAndGroups.js
@@ -1,56 +1,93 @@
-var Storage	 = require('../storage/storage');
+var Storage = require('../storage/storage');
 var Validator = require('../validation/validator');
 var Authentication = require('../authentication/authentication');
-var clone = require('clone');
-
 
 var Api = function (conf) {
-	  	  this.authentication = new Authentication(conf);
-   	    this.validator = new Validator(conf);
-				this.storage = new Storage(conf);
+    this.authentication = new Authentication(conf);
+    this.validator = new Validator(conf);
+    this.storage = new Storage(conf);
 };
 
-/*
-   This promisse is used to create entities
-*/
-Api.prototype.actionPromisse = function (token, action , entity_type , entity_id, entity) {
-   var promisse = new Promise(function(resolve, reject) {
+var entityNotExistCheck = this.storage.doesEntityNotExistCheck();
 
-        var auth = this.authentication.authenticateEntityPromisse(token);
-        auth.then(function(authenticationresult){
+/**
+ * This can only be used for adding, as it's rejects once the entity already exists,
+ * which is the case for read, update and delete.
+ * TODO Juan David Maybe remove this method?
+ */
+Api.prototype.actionPromisse = function (token, action, entity_type, entity_id, entity) {
+    return new Promise(function (resolve, reject) {
+        var auth_result;
+        this.authentication.authenticateEntityPromisse(token).then(function (authenticationresult) {
+            auth_result = authenticationresult;
+            return this.validator.validatePromisse(entity_type, entity);
+        }).then(function () {
+            entity["owner"] = auth_result["user_id"] + "!@!" + auth_result["auth_type"];
+            return entityNotExistCheck(entity_id, entity_type, entity);
+        }).then(this.storage.storageOperation(entity_id, entity_type, action, entity))
+            .then(function (storageresult) {
+                resolve(storageresult);
+            }).catch(function (err) {
+            reject(err);
+        });
+    });
+};
 
-						  var val = this.validator.validatePromisse(entity_type, entity);
-							val.then(function(validationresult){
+Api.prototype.createEntity = function (token, entity_type, entity_id, entity) {
+    return new Promise(function (resolve, reject) {
+        var auth_result;
+        this.authenticateEntityPromisse(token).then(function (result) {
+            auth_result = result;
+            return this.validator.validatePromisse(entity_type, entity);
+        }).then(function () {
+            entity["owner"] = auth_result["user_id"] + "!@!" + auth_result["auth_type"];
+            return entityNotExistCheck(entity_id, entity_type, entity);
+        }).then(this.storage.prototype.createEntity(entity_id, entity_type, entity))
+            .then(function (result) {
+                resolve(result);
+            }).catch(function (err) {
+            reject(err);
+        });
+    });
+};
 
-								    var finalEntity = clone(entity);
-										finalEntity["owner"] = authenticationresult["user_id"]+"!@!"+authenticationresult["auth_type"];
-										var read = this.storage.storageOperation( entity_id, entity_type ,"read", finalEntity);
-										read.then(function(storageresult){
-											   console.log("entity found: "+JSON.stringify(storageresult));
-												 reject(new Error("Creating and entity that already exists"));
-										}.bind(this)).catch(function(storageerror){
-												var stor = this.storage.storageOperation( entity_id, entity_type ,action , finalEntity);
-												stor.then(function(storageresult){
-														resolve(storageresult);
-												}.bind(this)).catch(function(storageerror){
-													 reject(storageerror);
-												}.bind(this));
+Api.prototype.readEntity = function (token, entity_type, entity_id, entity) {
+    return new Promise(function (resolve, reject) {
+        this.authenticateEntityPromisse(token)
+            .then(this.storage.prototype.readEntity(entity_id, entity_type, entity))
+            .then(function (result) {
+                resolve(result);
+            }).catch(function (err) {
+            reject(err);
+        });
+    });
+};
 
-										}.bind(this));
+Api.prototype.updateEntity = function (token, entity_type, entity_id, entity) {
+    return new Promise(function (resolve, reject) {
+        this.authenticateEntityPromisse(token)
+            .then(this.validator.validatePromisse(entity_type, entity))
+            .then(this.storage.readEntity(entity_id, entity_type, entity))
+            .then(this.storage.updateEntity(entity_id, entity_type, entity))
+            .then(function (result) {
+                resolve(result);
+            }).catch(function (err) {
+                reject(err);
+        })
+    });
+};
 
-
-
-
-							}.bind(this)).catch(function(validationerror){
-									reject(validationerror)
-							}.bind(this));
-
-        }.bind(this)).catch(function(error){
-             reject(error);
-        }.bind(this));
-
-   }.bind(this));
-   return promisse;
-}
+Api.prototype.deleteEntity = function (token, entity_type, entity_id, entity) {
+    return new Promise(function (resolve, reject) {
+        this.authenticateEntityPromisse(token)
+            .then(this.storage.readEntity(entity_id, entity_type, entity))
+            .then(this.storage.prototype.deleteEntity(entity_id, entity_type, entity))
+            .then(function (result) {
+                resolve(result);
+            }).catch(function (err) {
+            reject(err);
+        });
+    });
+};
 
 module.exports = Api;

--- a/lib/authentication/authentication.js
+++ b/lib/authentication/authentication.js
@@ -23,21 +23,16 @@ var Auth = function (conf) {
 */
 // THIS IS THE METHOD THAT SHOULD BE CALLED FROM THE OUTSIDE!!!
 Auth.prototype.authenticateEntityPromisse = function (credentials) {
-      var promisse = new Promise(function (resolve, reject){
-         var auth = this.idmHttpClient.authenticateEntityPromisse(credentials);
-         auth.then(function(data){
-           //TODO add time validation here... or does it happen on the server side?
-            var result = {"user_id": data["user_id"], "auth_type":data["auth_type"], "scope": data["scope"]}
+    return new Promise (function (resolve, reject) {
+        this.idmHttpClient.authenticateEntityPromisse(credentials).authenticateEntityPromisse(function (data) {
+            //TODO add time validation here... or does it happen on the server side?
+            var result = {"user_id": data["user_id"], "auth_type":data["auth_type"], "scope": data["scope"]};
             resolve(result);
-         }).catch(function(error){
-            console.log('auth wrong '+error);
-            reject(error);
-        });
-
-      }.bind(this));
-      return promisse;
-  }
-
-
+        }).catch(function (err) {
+            console.log('auth wrong' + error);
+            reject(err);
+        })
+    });
+};
 
 module.exports = Auth;

--- a/lib/storage/entity-connection-pool.js
+++ b/lib/storage/entity-connection-pool.js
@@ -2,30 +2,24 @@ var db = null;
 var EntityStorage = require('./sqlite3-storage');
 //This module just exposes one single instance of sqlite everywhere...
 
-function loadDb(conf,resolve,reject){
-
-      var promise  = new Promise(function (resolve, reject){
-
-        if(db){
-          return resolve(db);
-        }
-        else if(!conf.hasOwnProperty('storage')){
-          console.log(" cannot find storage configuration in Entity Storage");
-          reject(new Error("error: cannot find storage configuration in Entity Storage"));
-        }
-        else{
-          db = new EntityStorage();
-          db.init(conf['storage'], function(result){
-               if(result.success){
-                   return resolve(db);
-               }
-               else{
-                  console.log("unknown error");
-                   reject(new Error("error:"+result.error));
-               }
-           });
+function loadDb(conf) {
+    return new Promise(function (resolve, reject) {
+        if (db) {
+            return resolve(db);
+        } else if (!conf.hasOwnProperty('storage')) {
+            console.log(" cannot find storage configuration in Entity Storage");
+            reject(new Error("error: cannot find storage configuration in Entity Storage"));
+        } else {
+            db = new EntityStorage();
+            db.init(conf['storage'], function (result) {
+                if (result.success) {
+                    return resolve(db);
+                } else {
+                    console.log("unknown error");
+                    reject(new Error("error:" + result.error));
+                }
+            });
         }
     });
-    return promise;
 }
 module.exports = loadDb;

--- a/lib/storage/storage.js
+++ b/lib/storage/storage.js
@@ -1,43 +1,65 @@
-var  connectionPoolPromisse	 = require('./entity-connection-pool');
-var configuration = null;
+var connectionPoolPromisse = require('./entity-connection-pool');
 
 var Storage = function (conf) {
-  if(conf.hasOwnProperty("storage") && conf["storage"].hasOwnProperty("dbName")){
-    this.conf = conf;
-  }
-  else {
-    console.warn("Authentication module not properly configured!"+JSON.stringify(conf));
-    //throw new Error("Authentication module not properly configured!");
-  }
+    if (conf.hasOwnProperty("storage") && conf["storage"].hasOwnProperty("dbName")) {
+        this.conf = conf;
+    } else {
+        console.warn("Authentication module not properly configured!" + JSON.stringify(conf));
+        //throw new Error("Authentication module not properly configured!");
+    }
 };
 
-//action must be 	one of read create update delete
-Storage.prototype.storageOperation = function (id, entity_type ,action , data) {
-      var promisse = new Promise(function (resolve, reject){
-        connectionPoolPromisse(this.conf).then(function(storage){
-           storage.crudOperation(id , entity_type ,action , data, function(result){
-               if(result.hasOwnProperty("success") && result.success){
-                 if(result.hasOwnProperty("data"))
-                   return resolve(data);
-                else
-                  return resolve();
-               }
-               else{
-                 if(result.hasOwnProperty("error"))
-                  return reject(new Error(result.error));
-                else
-                  return reject(new Error("unexpected storage error"));
-               }
-           });
-
-        }).catch(function(error){
-              console.log('cannot load database error'+JSON.stringify(error));
+/**
+ * Action must be one of 'create', 'read', 'update' or 'delete'.
+ */
+Storage.prototype.storageOperation = function (id, entity_type, action, data) {
+    return new Promise(function (resolve, reject) {
+        connectionPoolPromisse(this.conf).then(function (storage) {
+            storage.crudOperation(id, entity_type, action, data).then(function (result) {
+                if (result.hasOwnProperty("success") && result.success) {
+                    resolve(result.data);
+                } else {
+                    reject(new Error(result.hasOwnProperty("error") ? result.error : "unexpected storage error"));
+                }
+            });
         });
+    });
+};
 
-      }.bind(this));
-      return promisse;
-  }
+Storage.prototype.createEntity = function (id, entity_type, data) {
+    return this.prototype.crudOperation(id, entity_type, 'create', data);
+};
+
+Storage.prototype.readEntity = function (id, entity_type, data) {
+    return this.prototype.crudOperation(id, entity_type, 'read', data);
+};
+
+Storage.prototype.updateEntity = function (id, entity_type, data) {
+    return this.prototype.crudOperation(id, entity_type, 'update', data);
+};
+
+Storage.prototype.deleteEntity = function (id, entity_type, data) {
+    return this.prototype.crudOperation(id, entity_type, 'delete', data);
+};
 
 
+
+
+/**
+ * Returns a resolved Promise when the entity is NOT found.
+ * Returns a rejected Promise when the entity is found.
+ *
+ * @returns {Promise} whether the given entity already exists or not.
+ */
+Storage.prototype.doesEntityNotExistCheck = function (id, entity_type, data) {
+    return new Promise(function (resolve, reject) {
+        this.prototype.storageOperation(id, entity_type, 'read', data).then(function () {
+            console.log("entity found: " + JSON.stringify(storageresult));
+            reject(new Error("Entity exists already."));
+        }).catch(function () {
+            resolve();
+        });
+    });
+};
 
 module.exports = Storage;

--- a/lib/validation/validator.js
+++ b/lib/validation/validator.js
@@ -1,45 +1,38 @@
 var Validator = require('jsonschema').Validator;
 var v = new Validator();
 
-
 // ------------------------- validate module -------------------------------------------
 
 var MyModule = function (conf) {
-
 	if(conf.hasOwnProperty("schema-validation")){
-	  var schemas =conf["schema-validation"];
+	  var schemas = conf["schema-validation"];
 		for(var i in schemas){
 			v.addSchema(schemas[i],schemas[i]['id']);
 		}
-	}
-	else {
+	} else {
 		throw new Error("Validator module not property configured!");
 	}
 };
 
 
 MyModule.prototype.validatePromisse = function (entity_type, data) {
-	var promisse = new Promise(function (resolve, reject){
-			try{
-				var resultvalid = v.validate(data, entity_type);
-				if(resultvalid.errors.length == 0){
-					return resolve();
+	return new Promise(function (resolve, reject) {
+		try {
+			var resultvalid = v.validate(data, entity_type);
+			if (resultvalid.errors.length == 0) {
+				return resolve();
+			} else {
+				var array = [];
+				for (var i in resultvalid.errors) {
+					array.push(resultvalid.errors[i].property + " " + resultvalid.errors[i].message);
 				}
-				else{
-					var array = [];
-					for(var i in resultvalid.errors){
-					    array.push(resultvalid.errors[i].property+" "+resultvalid.errors[i].message );
-					}
-					return reject(new Error(JSON.stringify(array)));
-				}
-
-			}catch(error){
-				return  reject(error);
+				return reject(new Error(JSON.stringify(array)));
 			}
 
+		} catch (error) {
+			return reject(error);
+		}
 	});
-	return promisse;
-
-}
+};
 
 module.exports = MyModule;


### PR DESCRIPTION
Refactored some parts, especially promise usage.
The `actionPromisse` method in `entityAndGroups` rejected most CRUD actions, based on the existence of the entity, which is the case for read, update and delete.
As a method for adding (the only functionality `actionPromisse` had) is implemented, the `actionPromisse` method could be removed.

As `npm start` is not defined and `npm test` only tests the database, the pull request could yet not be tested.
The refactoring parts didn't change the functionality, but adding own methods for crud operations did. In this part a review is needed.
